### PR TITLE
Devt (#871) - Pull from bdring/Grbl_Esp32

### DIFF
--- a/Grbl_Esp32/src/Grbl.cpp
+++ b/Grbl_Esp32/src/Grbl.cpp
@@ -30,7 +30,7 @@ void grbl_init() {
     WiFi.enableSTA(false);
     WiFi.enableAP(false);
     WiFi.mode(WIFI_OFF);
-    serial_init();  // Setup serial baud rate and interrupts
+    client_init();  // Setup serial baud rate and interrupts
     display_init();
     grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Grbl_ESP32 Ver %s Date %s", GRBL_VERSION, GRBL_VERSION_BUILD);  // print grbl_esp32 verion info
     grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Compiled with ESP32 SDK:%s", ESP.getSdkVersion());              // print the SDK version
@@ -40,7 +40,7 @@ void grbl_init() {
 #endif
     settings_init();  // Load Grbl settings from non-volatile storage
     stepper_init();   // Configure stepper pins and interrupt timers
-    system_ini();  // Configure pinout pins and pin-change interrupt (Renamed due to conflict with esp32 files)
+    system_ini();     // Configure pinout pins and pin-change interrupt (Renamed due to conflict with esp32 files)
     init_motors();
     memset(sys_position, 0, sizeof(sys_position));  // Clear machine position.
     machine_init();                                 // weak definition in Grbl.cpp does nothing
@@ -93,8 +93,8 @@ static void reset_variables() {
     sys_rt_s_override                    = SpindleSpeedOverride::Default;
 
     // Reset Grbl primary systems.
-    serial_reset_read_buffer(CLIENT_ALL);  // Clear serial read buffer
-    gc_init();                             // Set g-code parser to default state
+    client_reset_read_buffer(CLIENT_ALL);
+    gc_init();  // Set g-code parser to default state
     spindle->stop();
     coolant_init();
     limits_init();

--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -22,7 +22,7 @@
 
 // Grbl versioning system
 const char* const GRBL_VERSION       = "1.3a";
-const char* const GRBL_VERSION_BUILD = "20210401";
+const char* const GRBL_VERSION_BUILD = "20210419";
 
 //#include <sdkconfig.h>
 #include <Arduino.h>
@@ -51,8 +51,9 @@ const char* const GRBL_VERSION_BUILD = "20210401";
 #include "Limits.h"
 #include "MotionControl.h"
 #include "Protocol.h"
-#include "Report.h"
+#include "Uart.h"
 #include "Serial.h"
+#include "Report.h"
 #include "Pins.h"
 #include "Spindles/Spindle.h"
 #include "Motors/Motors.h"

--- a/Grbl_Esp32/src/I2SOut.cpp
+++ b/Grbl_Esp32/src/I2SOut.cpp
@@ -48,6 +48,7 @@
 #include "WebUI/ESPResponse.h"
 #include "Probe.h"
 #include "System.h"
+#include "Serial.h"
 #include "Report.h"
 
 #include <FreeRTOS.h>

--- a/Grbl_Esp32/src/Limits.cpp
+++ b/Grbl_Esp32/src/Limits.cpp
@@ -55,10 +55,12 @@ void IRAM_ATTR isr_limit_switches() {
 #    ifdef HARD_LIMIT_FORCE_STATE_CHECK
             // Check limit pin state.
             if (limits_get_state()) {
+                grbl_msg_sendf(CLIENT_ALL, MsgLevel::Debug, "Hard limits");
                 mc_reset();                                // Initiate system kill.
                 sys_rt_exec_alarm = ExecAlarm::HardLimit;  // Indicate hard limit critical event
             }
 #    else
+            grbl_msg_sendf(CLIENT_ALL, MsgLevel::Debug, "Hard limits");
             mc_reset();                                // Initiate system kill.
             sys_rt_exec_alarm = ExecAlarm::HardLimit;  // Indicate hard limit critical event
 #    endif
@@ -195,7 +197,8 @@ void limits_go_home(uint8_t cycle_mask) {
 
                 if (sys_rt_exec_alarm != ExecAlarm::None) {
                     motors_set_homing_mode(cycle_mask, false);  // tell motors homing is done...failed
-                    mc_reset();                                 // Stop motors, if they are running.
+                    grbl_msg_sendf(CLIENT_ALL, MsgLevel::Debug, "Homing fail");
+                    mc_reset();  // Stop motors, if they are running.
                     protocol_execute_realtime();
                     return;
                 } else {
@@ -351,6 +354,7 @@ void limits_soft_check(float* target) {
                 }
             } while (sys.state != State::Idle);
         }
+        grbl_msg_sendf(CLIENT_ALL, MsgLevel::Debug, "Soft limits");
         mc_reset();                                // Issue system reset and ensure spindle and coolant are shutdown.
         sys_rt_exec_alarm = ExecAlarm::SoftLimit;  // Indicate soft limit critical event
         protocol_execute_realtime();               // Execute to enter critical event loop and system abort
@@ -367,7 +371,7 @@ void limitCheckTask(void* pvParameters) {
         AxisMask switch_state;
         switch_state = limits_get_state();
         if (switch_state) {
-            //grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Limit Switch State %08d", switch_state);
+            grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Debug, "Limit Switch State %08d", switch_state);
             mc_reset();                                // Initiate system kill.
             sys_rt_exec_alarm = ExecAlarm::HardLimit;  // Indicate hard limit critical event
         }

--- a/Grbl_Esp32/src/MotionControl.cpp
+++ b/Grbl_Esp32/src/MotionControl.cpp
@@ -499,6 +499,7 @@ void mc_override_ctrl_update(uint8_t override_state) {
 // lost, since there was an abrupt uncontrolled deceleration. Called at an interrupt level by
 // realtime abort command and hard limits. So, keep to a minimum.
 void mc_reset() {
+    grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Debug, "mc_reset()");
     // Only this function can set the system reset. Helps prevent multiple kill calls.
     if (!sys_rt_exec_state.bit.reset) {
         sys_rt_exec_state.bit.reset = true;

--- a/Grbl_Esp32/src/Motors/TrinamicUartDriver.h
+++ b/Grbl_Esp32/src/Motors/TrinamicUartDriver.h
@@ -21,6 +21,7 @@
 
 #include "Motor.h"
 #include "StandardStepper.h"
+#include "../Uart.h"
 
 #include <TMCStepper.h>  // https://github.com/teemuatlut/TMCStepper
 
@@ -63,7 +64,7 @@ const double TRINAMIC_UART_FCLK = 12700000.0;  // Internal clock Approx (Hz) use
 #    define TMC_UART_TX UNDEFINED_PIN
 #endif
 
-extern HardwareSerial tmc_serial;
+extern Uart tmc_serial;
 
 namespace Motors {
 
@@ -75,6 +76,9 @@ namespace Motors {
     };
 
     class TrinamicUartDriver : public StandardStepper {
+    private:
+        static bool _uart_started;
+
     public:
         TrinamicUartDriver(uint8_t  axis_index,
                            uint8_t  step_pin,

--- a/Grbl_Esp32/src/ProcessSettings.cpp
+++ b/Grbl_Esp32/src/ProcessSettings.cpp
@@ -192,6 +192,7 @@ Error toggle_check_mode(const char* value, WebUI::AuthenticationLevel auth_level
     // is idle and ready, regardless of alarm locks. This is mainly to keep things
     // simple and consistent.
     if (sys.state == State::CheckMode) {
+        grbl_msg_sendf(CLIENT_ALL, MsgLevel::Debug, "Check mode");
         mc_reset();
         report_feedback_message(Message::Disabled);
     } else {

--- a/Grbl_Esp32/src/Protocol.cpp
+++ b/Grbl_Esp32/src/Protocol.cpp
@@ -103,7 +103,7 @@ bool can_park() {
   GRBL PRIMARY LOOP:
 */
 void protocol_main_loop() {
-    serial_reset_read_buffer(CLIENT_ALL);
+    client_reset_read_buffer(CLIENT_ALL);
     empty_lines();
     //uint8_t client = CLIENT_SERIAL; // default client
     // Perform some machine checks to make sure everything is good to go.
@@ -135,7 +135,7 @@ void protocol_main_loop() {
     // Primary loop! Upon a system abort, this exits back to main() to reset the system.
     // This is also where Grbl idles while waiting for something to do.
     // ---------------------------------------------------------------------------------
-    uint8_t c;
+    int c;
     for (;;) {
 #ifdef ENABLE_SD_CARD
         if (SD_ready_next) {
@@ -157,7 +157,7 @@ void protocol_main_loop() {
         uint8_t client = CLIENT_SERIAL;
         char*   line;
         for (client = 0; client < CLIENT_COUNT; client++) {
-            while ((c = serial_read(client)) != SERIAL_NO_DATA) {
+            while ((c = client_read(client)) != -1) {
                 Error res = add_char_to_line(c, client);
                 switch (res) {
                     case Error::Ok:

--- a/Grbl_Esp32/src/Report.cpp
+++ b/Grbl_Esp32/src/Report.cpp
@@ -54,30 +54,8 @@ EspClass esp;
 #endif
 const int DEFAULTBUFFERSIZE = 64;
 
-// this is a generic send function that everything should use, so interfaces could be added (Bluetooth, etc)
 void grbl_send(uint8_t client, const char* text) {
-    if (client == CLIENT_INPUT) {
-        return;
-    }
-#ifdef ENABLE_BLUETOOTH
-    if (WebUI::SerialBT.hasClient() && (client == CLIENT_BT || client == CLIENT_ALL)) {
-        WebUI::SerialBT.print(text);
-        //delay(10); // possible fix for dropped characters
-    }
-#endif
-#if defined(ENABLE_WIFI) && defined(ENABLE_HTTP) && defined(ENABLE_SERIAL2SOCKET_OUT)
-    if (client == CLIENT_WEBUI || client == CLIENT_ALL) {
-        WebUI::Serial2Socket.write((const uint8_t*)text, strlen(text));
-    }
-#endif
-#if defined(ENABLE_WIFI) && defined(ENABLE_TELNET)
-    if (client == CLIENT_TELNET || client == CLIENT_ALL) {
-        WebUI::telnet_server.write((const uint8_t*)text, strlen(text));
-    }
-#endif
-    if (client == CLIENT_SERIAL || client == CLIENT_ALL) {
-        Serial.print(text);
-    }
+    client_write(client, text);
 }
 
 // This is a formating version of the grbl_send(CLIENT_ALL,...) function that work like printf
@@ -658,7 +636,7 @@ void report_realtime_status(uint8_t client) {
         }
 #    endif  //ENABLE_BLUETOOTH
         if (client == CLIENT_SERIAL) {
-            bufsize = serial_get_rx_buffer_available(CLIENT_SERIAL);
+            bufsize = client_get_rx_buffer_available(CLIENT_SERIAL);
         }
         sprintf(temp, "|Bf:%d,%d", plan_get_block_buffer_available(), bufsize);
         strcat(status, temp);

--- a/Grbl_Esp32/src/Serial.h
+++ b/Grbl_Esp32/src/Serial.h
@@ -20,7 +20,7 @@
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "Grbl.h"
+#include "stdint.h"
 
 #ifndef RX_BUFFER_SIZE
 #    define RX_BUFFER_SIZE 256
@@ -33,24 +33,22 @@
 #    endif
 #endif
 
-const float SERIAL_NO_DATA = 0xff;
-
 // a task to read for incoming data from serial port
-void serialCheckTask(void* pvParameters);
+void clientCheckTask(void* pvParameters);
 
-void serial_write(uint8_t data);
+void client_write(uint8_t client, const char* text);
+
 // Fetches the first byte in the serial read buffer. Called by main program.
-uint8_t serial_read(uint8_t client);
+int client_read(uint8_t client);
 
 // See if the character is an action command like feedhold or jogging. If so, do the action and return true
 uint8_t check_action_command(uint8_t data);
 
-void serial_init();
-void serial_reset_read_buffer(uint8_t client);
+void client_init();
+void client_reset_read_buffer(uint8_t client);
 
 // Returns the number of bytes available in the RX serial buffer.
-uint8_t serial_get_rx_buffer_available(uint8_t client);
+uint8_t client_get_rx_buffer_available(uint8_t client);
 
 void execute_realtime_command(Cmd command, uint8_t client);
-bool any_client_has_data();
 bool is_realtime_command(uint8_t data);

--- a/Grbl_Esp32/src/Spindles/H2ASpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/H2ASpindle.cpp
@@ -28,17 +28,10 @@
     managed to piece together.
 */
 
-#include <driver/uart.h>
-
 namespace Spindles {
-    void H2A::default_modbus_settings(uart_config_t& uart) {
-        // sets the uart to 19200 8E1
-        VFD::default_modbus_settings(uart);
-
-        uart.baud_rate = 19200;
-        uart.data_bits = UART_DATA_8_BITS;
-        uart.parity    = UART_PARITY_EVEN;
-        uart.stop_bits = UART_STOP_BITS_1;
+    H2A::H2A() : VFD() {
+        _baudrate = 19200;
+        _parity   = Uart::Parity::Even;
     }
 
     void H2A::direction_command(SpindleState mode, ModbusCommand& data) {

--- a/Grbl_Esp32/src/Spindles/H2ASpindle.h
+++ b/Grbl_Esp32/src/Spindles/H2ASpindle.h
@@ -24,8 +24,6 @@
 namespace Spindles {
     class H2A : public VFD {
     protected:
-        void default_modbus_settings(uart_config_t& uart) override;
-
         void direction_command(SpindleState mode, ModbusCommand& data) override;
         void set_speed_command(uint32_t rpm, ModbusCommand& data) override;
 
@@ -36,5 +34,8 @@ namespace Spindles {
 
         bool supports_actual_rpm() const override { return true; }
         bool safety_polling() const override { return false; }
+
+    public:
+        H2A();
     };
 }

--- a/Grbl_Esp32/src/Spindles/HuanyangSpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/HuanyangSpindle.cpp
@@ -149,15 +149,10 @@
     If the frequency is -say- 25 Hz, Huanyang wants us to send 2500 (eg. 25.00 Hz).
 */
 
-#include <driver/uart.h>
-
 namespace Spindles {
-    void Huanyang::default_modbus_settings(uart_config_t& uart) {
-        // sets the uart to 9600 8N1
-        VFD::default_modbus_settings(uart);
-
-        // uart.baud_rate = 9600;
-        // Baud rate is set in the PD164 setting.
+    Huanyang::Huanyang() : VFD() {
+        // Baud rate is set in the PD164 setting.  If it is not 9600, add, for example,
+        // _baudrate = 19200;
     }
 
     void Huanyang::direction_command(SpindleState mode, ModbusCommand& data) {

--- a/Grbl_Esp32/src/Spindles/HuanyangSpindle.h
+++ b/Grbl_Esp32/src/Spindles/HuanyangSpindle.h
@@ -35,8 +35,6 @@ namespace Spindles {
 
         void updateRPM();
 
-        void default_modbus_settings(uart_config_t& uart) override;
-
         void direction_command(SpindleState mode, ModbusCommand& data) override;
         void set_speed_command(uint32_t rpm, ModbusCommand& data) override;
 
@@ -45,5 +43,8 @@ namespace Spindles {
         response_parser get_current_rpm(ModbusCommand& data) override;
 
         bool supports_actual_rpm() const override { return true; }
+
+    public:
+        Huanyang();
     };
 }

--- a/Grbl_Esp32/src/Spindles/VFDSpindle.h
+++ b/Grbl_Esp32/src/Spindles/VFDSpindle.h
@@ -20,11 +20,12 @@
 */
 #include "Spindle.h"
 
-#include <driver/uart.h>
+#include "../Uart.h"
 
 // #define VFD_DEBUG_MODE
 
 namespace Spindles {
+    extern Uart _uart;
 
     class VFD : public Spindle {
     private:
@@ -34,9 +35,9 @@ namespace Spindles {
         bool set_mode(SpindleState mode, bool critical);
         bool get_pins_and_settings();
 
-        uint8_t _txd_pin;
-        uint8_t _rxd_pin;
-        uint8_t _rts_pin;
+        int _txd_pin;
+        int _rxd_pin;
+        int _rts_pin;
 
         uint32_t _current_rpm  = 0;
         bool     _task_running = false;
@@ -57,8 +58,6 @@ namespace Spindles {
             uint8_t msg[VFD_RS485_MAX_MSG_SIZE];
         };
 
-        virtual void default_modbus_settings(uart_config_t& uart);
-
         // Commands:
         virtual void direction_command(SpindleState mode, ModbusCommand& data) = 0;
         virtual void set_speed_command(uint32_t rpm, ModbusCommand& data)      = 0;
@@ -73,8 +72,14 @@ namespace Spindles {
         virtual bool            supports_actual_rpm() const { return false; }
         virtual bool            safety_polling() const { return true; }
 
+        // The constructor sets these
+        int          _baudrate;
+        Uart::Data   _dataBits;
+        Uart::Stop   _stopBits;
+        Uart::Parity _parity;
+
     public:
-        VFD()           = default;
+        VFD();
         VFD(const VFD&) = delete;
         VFD(VFD&&)      = delete;
         VFD& operator=(const VFD&) = delete;

--- a/Grbl_Esp32/src/Spindles/YL620Spindle.h
+++ b/Grbl_Esp32/src/Spindles/YL620Spindle.h
@@ -24,10 +24,8 @@
 namespace Spindles {
     class YL620 : public VFD {
     protected:
-        uint16_t _minFrequency = 0;    // frequency lower limit. Factor 10 of actual frequency
+        uint16_t _minFrequency = 0;     // frequency lower limit. Factor 10 of actual frequency
         uint16_t _maxFrequency = 4000;  // max frequency the VFD will allow. Normally 400.0. Factor 10 of actual frequency
-        
-        void default_modbus_settings(uart_config_t& uart) override;
 
         void direction_command(SpindleState mode, ModbusCommand& data) override;
         void set_speed_command(uint32_t rpm, ModbusCommand& data) override;
@@ -39,5 +37,8 @@ namespace Spindles {
 
         bool supports_actual_rpm() const override { return true; }
         bool safety_polling() const override { return false; }
+
+    public:
+        YL620();
     };
 }

--- a/Grbl_Esp32/src/Uart.cpp
+++ b/Grbl_Esp32/src/Uart.cpp
@@ -1,0 +1,94 @@
+/*
+ * UART driver that accesses the ESP32 hardware FIFOs directly.
+ */
+
+#include "Grbl.h"
+
+#include "esp_system.h"
+#include "soc/uart_reg.h"
+#include "soc/io_mux_reg.h"
+#include "soc/gpio_sig_map.h"
+#include "soc/dport_reg.h"
+#include "soc/rtc.h"
+
+Uart::Uart(int uart_num) : _uart_num(uart_port_t(uart_num)), _pushback(-1) {}
+
+void Uart::begin(unsigned long baudrate, Data dataBits, Stop stopBits, Parity parity) {
+    //    uart_driver_delete(_uart_num);
+    uart_config_t conf;
+    conf.baud_rate           = baudrate;
+    conf.data_bits           = uart_word_length_t(dataBits);
+    conf.parity              = uart_parity_t(parity);
+    conf.stop_bits           = uart_stop_bits_t(stopBits);
+    conf.flow_ctrl           = UART_HW_FLOWCTRL_DISABLE;
+    conf.rx_flow_ctrl_thresh = 0;
+    conf.use_ref_tick        = false;
+    if (uart_param_config(_uart_num, &conf) != ESP_OK) {
+        return;
+    };
+    uart_driver_install(_uart_num, 256, 0, 0, NULL, 0);
+}
+
+int Uart::available() {
+    size_t size = 0;
+    uart_get_buffered_data_len(_uart_num, &size);
+    return size + (_pushback >= 0);
+}
+
+int Uart::peek() {
+    _pushback = read();
+    return _pushback;
+}
+
+int Uart::read(TickType_t timeout) {
+    if (_pushback >= 0) {
+        int ret   = _pushback;
+        _pushback = -1;
+        return ret;
+    }
+    uint8_t c;
+    int     res = uart_read_bytes(_uart_num, &c, 1, timeout);
+    return res != 1 ? -1 : c;
+}
+int Uart::read() {
+    return read(0);
+}
+
+size_t Uart::readBytes(char* buffer, size_t length, TickType_t timeout) {
+    bool pushback = _pushback >= 0;
+    if (pushback && length) {
+        *buffer++ = _pushback;
+        _pushback = -1;
+        --length;
+    }
+    int res = uart_read_bytes(_uart_num, (uint8_t*)buffer, length, timeout);
+    // The Stream class version of readBytes never returns -1,
+    // so if uart_read_bytes returns -1, we change that to 0
+    return pushback + (res >= 0 ? res : 0);
+}
+size_t Uart::readBytes(char* buffer, size_t length) {
+    return readBytes(buffer, length, (TickType_t)0);
+}
+size_t Uart::write(uint8_t c) {
+    return uart_write_bytes(_uart_num, (char*)&c, 1);
+}
+
+size_t Uart::write(const uint8_t* buffer, size_t length) {
+    return uart_write_bytes(_uart_num, (const char*)buffer, length);
+}
+
+size_t Uart::write(const char* text) {
+    return uart_write_bytes(_uart_num, text, strlen(text));
+}
+
+bool Uart::setHalfDuplex() {
+    return uart_set_mode(_uart_num, UART_MODE_RS485_HALF_DUPLEX) != ESP_OK;
+}
+bool Uart::setPins(int tx_pin, int rx_pin, int rts_pin, int cts_pin) {
+    return uart_set_pin(_uart_num, tx_pin, rx_pin, rts_pin, cts_pin) != ESP_OK;
+}
+bool Uart::flushTxTimed(TickType_t ticks) {
+    return uart_wait_tx_done(_uart_num, ticks) != ESP_OK;
+}
+
+Uart Uart0(0);

--- a/Grbl_Esp32/src/Uart.h
+++ b/Grbl_Esp32/src/Uart.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <driver/uart.h>
+
+class Uart : public Stream {
+private:
+    uart_port_t _uart_num;
+    int         _pushback;
+
+public:
+    enum class Data : int {
+        Bits5 = UART_DATA_5_BITS,
+        Bits6 = UART_DATA_6_BITS,
+        Bits7 = UART_DATA_7_BITS,
+        Bits8 = UART_DATA_8_BITS,
+    };
+
+    enum class Stop : int {
+        Bits1   = UART_STOP_BITS_1,
+        Bits1_5 = UART_STOP_BITS_1_5,
+        Bits2   = UART_STOP_BITS_2,
+    };
+
+    enum class Parity : int {
+        None = UART_PARITY_DISABLE,
+        Even = UART_PARITY_EVEN,
+        Odd  = UART_PARITY_ODD,
+    };
+
+    Uart(int uart_num);
+    bool          setHalfDuplex();
+    bool          setPins(int tx_pin, int rx_pin, int rts_pin = -1, int cts_pin = -1);
+    void          begin(unsigned long baud, Data dataBits, Stop stopBits, Parity parity);
+    int           available(void) override;
+    int           read(void) override;
+    int           read(TickType_t timeout);
+    size_t        readBytes(char* buffer, size_t length, TickType_t timeout);
+    size_t        readBytes(uint8_t* buffer, size_t length, TickType_t timeout) { return readBytes((char*)buffer, length, timeout); }
+    size_t        readBytes(char* buffer, size_t length) override;
+    int           peek(void) override;
+    size_t        write(uint8_t data);
+    size_t        write(const uint8_t* buffer, size_t length);
+    inline size_t write(const char* buffer, size_t size) { return write((uint8_t*)buffer, size); }
+    size_t        write(const char* text);
+    void          flush() { uart_flush(_uart_num); }
+    bool          flushTxTimed(TickType_t ticks);
+};
+
+extern Uart Uart0;

--- a/platformio.ini
+++ b/platformio.ini
@@ -63,10 +63,10 @@ src_filter =
 [env:release]
 lib_deps = 
     TMCStepper@>=0.7.0,<1.0.0
-    squix78/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.2.0
+    ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.2.0
 
 [env:debug]
 build_type = debug
 lib_deps = 
     TMCStepper@>=0.7.0,<1.0.0
-    squix78/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.2.0
+    ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.2.0


### PR DESCRIPTION
* Oled2 (#834)

* WIP

* WIP

* Update platformio.ini

* WIP

* Cleanup

* Update platformio.ini

* Turn off soft limits with max travel (#836)

https://github.com/bdring/Grbl_Esp32/issues/831

* Yalang YL620 VFD (#838)

* New SpindleType YL620

Files for new SpindleType Yalang 620. So far the contents are a duplicate of H2ASpindle.h and H2ASpindle.cpp

* Added register documentation and implemented read and write data packets

* Some fixes, mostly regarding RX packet length

* OLED and Other Updates (#844)

* publish

* Updates - CoreXY and OLED

- Moved position calculation out of report_realtime_status(...) so other functions can access it.
- Added a function to check if a limit switch is defined
- CoreXY fixed bug in forward kinematics when midtbot is used.
- Modified OLED display.

* Cleanup for PR

* Delete midtbot_x2.h

* Incorporated PR 846

- Some OLED cleanup
- verified correct forward kinematics on MidTbot

* Pio down rev (#850)

* Update platformio.ini

* Update Grbl.h

* Use local UART driver not HardwareSerial (#857)

* Use local UART driver not HardwareSerial

The HardwareSerial driver is broken in Arduino framework versions
1.0.5 and 1.0.6 .  https://github.com/espressif/arduino-esp32/issues/5005
Instead of waiting for a fix, I wrote a very simple UART driver that
does exactly what we need with no unnecessary bells and whistles to
cause problems.

* Added missing files, changed method signatures

The methods implemented by the UART class now
have the same signatures as the HardwareSerial
class, so it will be easy to switch back if we
need to.

* Incorporated suggestions from Stefan

* Fixed TX_IDLE_NUM bug reported by mstrens

* Quick test for Bf: problem

This is not the final solution.

* Fixed stupid typo in last commit

* Another test - check for client_buffer space

* Use the esp-idf uart driver

You can revert to the direct driver for testing by
defining DIRECT_UART

* Uart class now supports VFD and TMC

* data bits, stop bits, parity as enum classes

The constants for data bits, stop bits, and parity
were changed to enum classes so the compiler can
check for argument order mismatches.

* Set half duplex after uart init

* Init TMC UART only once

* rx/tx pin order mixup, missing _uart_started

* Test: use Arduino Serial

This reverts to the Arduino serial driver for
UI communication, leaving the VFS comms on the
Uart class on top of the esp_idf UART driver.

You can switch back and forth with the
   define REVERT_TO_SERIAL
line in Serial.cpp

* REVERT_TO_ARDUINO_SERIAL off by default

* Added debug messages

* Update Grbl.h

* Update platformio.ini

Co-authored-by: bdring <barton.dring@gmail.com>

* Fixed spindle sync for all VFD spindles (#868)

* Implemented H2A spindle sync fix. Untested.

* Changed the spindle sync fix to be in the VFD code.

* Update Grbl.h

Co-authored-by: Stefan de Bruijn <stefan@nubilosoft.com>
Co-authored-by: bdring <barton.dring@gmail.com>

Co-authored-by: Mitch Bradley <wmb@firmworks.com>
Co-authored-by: marcosprojects <marco1601@web.de>
Co-authored-by: Stefan de Bruijn <atlaste@users.noreply.github.com>
Co-authored-by: Stefan de Bruijn <stefan@nubilosoft.com>